### PR TITLE
Do not depend on removed feature `bls12_381_plus/hashing`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ repository = "https://github.com/zkcrypto/jubjub"
 version = "0.10.0"
 edition = "2021"
 
+[dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = false }
+
 [dependencies.bitvec]
 version = "1"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ edition = "2021"
 version = "1"
 default-features = false
 
-[dependencies.bls12_381]
+[dependencies.bls12_381_plus]
 version = "0.8"
+features = ["groups", "bits", "hashing"]
 default-features = false
 
 [dependencies.ff]
@@ -47,7 +48,7 @@ default-features = false
 
 [features]
 default = ["alloc", "bits"]
-alloc = ["ff/alloc", "group/alloc"]
+alloc = ["ff/alloc", "group/alloc", "bls12_381_plus/alloc"]
 bits = ["ff/bits"]
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/zkcrypto/jubjub"
 license = "MIT/Apache-2.0"
 name = "jubjub"
 repository = "https://github.com/zkcrypto/jubjub"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ homepage = "https://github.com/zkcrypto/jubjub"
 license = "MIT/Apache-2.0"
 name = "jubjub"
 repository = "https://github.com/zkcrypto/jubjub"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", default-features = false, optional = false }
+serde = "1.0"
 
 [dependencies.bitvec]
 version = "1"
@@ -62,6 +62,7 @@ default = ["std", "bits"]
 std = ["alloc", "bits", "bls12_381_plus/std"]
 alloc = ["ff/alloc", "group/alloc", "bls12_381_plus/alloc"]
 bits = ["ff/bits"]
+serde = ["serde"]
 
 [[bench]]
 name = "fq_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/zkcrypto/jubjub"
 license = "MIT/Apache-2.0"
 name = "jubjub"
 repository = "https://github.com/zkcrypto/jubjub"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ version = "0.8"
 features = ["groups", "bits", "hashing"]
 default-features = false
 
+[dependencies.elliptic-curve]
+version = "0.13"
+features = ["hash2curve"]
+
 [dependencies.ff]
 version = "0.13"
 default-features = false
@@ -38,10 +42,13 @@ default-features = false
 version = "2.5.0"
 default-features = false
 
+[dependencies.rand_chacha]
+version = "0.3"
+
 [dev-dependencies]
 criterion = "0.3"
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
-vsss-rs = "3.3.2"
+vsss-rs = "3.3.4"
 
 [dev-dependencies.rand_xorshift]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default-features = false
 
 [dependencies.bls12_381_plus]
 version = "0.8"
-features = ["groups", "bits", "hashing"]
+features = ["groups", "bits"]
 default-features = false
 
 [dependencies.elliptic-curve]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ homepage = "https://github.com/zkcrypto/jubjub"
 license = "MIT/Apache-2.0"
 name = "jubjub"
 repository = "https://github.com/zkcrypto/jubjub"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 
 [dependencies]
-serde = "1.0"
+serde = { version = "1.0", optional = true }
 
 [dependencies.bitvec]
 version = "1"
@@ -58,11 +58,10 @@ version = "0.3"
 default-features = false
 
 [features]
-default = ["std", "bits"]
+default = ["std", "bits", "serde"]
 std = ["alloc", "bits", "bls12_381_plus/std"]
 alloc = ["ff/alloc", "group/alloc", "bls12_381_plus/alloc"]
 bits = ["ff/bits"]
-serde = ["serde"]
 
 [[bench]]
 name = "fq_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.10.0"
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", default-features = false, features = ["derive"], optional = false }
+serde = { version = "1.0", default-features = false, optional = false }
 
 [dependencies.bitvec]
 version = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,15 @@ default-features = false
 [dev-dependencies]
 criterion = "0.3"
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
+vsss-rs = "3.3.2"
 
 [dev-dependencies.rand_xorshift]
 version = "0.3"
 default-features = false
 
 [features]
-default = ["alloc", "bits"]
+default = ["std", "bits"]
+std = ["alloc", "bits", "bls12_381_plus/std"]
 alloc = ["ff/alloc", "group/alloc", "bls12_381_plus/alloc"]
 bits = ["ff/bits"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,10 @@ repository = "https://github.com/zkcrypto/jubjub"
 version = "0.10.4"
 edition = "2021"
 
-[dependencies]
-serde = { version = "1.0", optional = true }
+[dependencies.serde]
+version = "1.0"
+default-features = false
+optional = true
 
 [dependencies.bitvec]
 version = "1"
@@ -48,10 +50,17 @@ default-features = false
 [dependencies.rand_chacha]
 version = "0.3"
 
+[dependencies.hex]
+version = "0.4"
+default-features = false
+optional = true
+
 [dev-dependencies]
 criterion = "0.3"
 csv = ">= 1.0, < 1.2" # csv 1.2 has MSRV 1.60
 vsss-rs = "3.3.4"
+serde_json = "1.0"
+serde_bare = "0.5"
 
 [dev-dependencies.rand_xorshift]
 version = "0.3"
@@ -62,6 +71,7 @@ default = ["std", "bits", "serde"]
 std = ["alloc", "bits", "bls12_381_plus/std"]
 alloc = ["ff/alloc", "group/alloc", "bls12_381_plus/alloc"]
 bits = ["ff/bits"]
+serde = ["dep:serde", "hex"]
 
 [[bench]]
 name = "fq_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ version = "0.6"
 default-features = false
 
 [dependencies.subtle]
-version = "^2.2.1"
+version = "2.5.0"
 default-features = false
 
 [dev-dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.0"
+channel = "1.72.0"
 components = [ "clippy", "rustfmt" ]

--- a/src/fr.rs
+++ b/src/fr.rs
@@ -666,7 +666,8 @@ impl Fr {
 
     /// Hash data to a scalar
     pub fn hash<X>(msg: &[u8], dst: &[u8]) -> Self
-        where X: for<'a> elliptic_curve::hash2curve::ExpandMsg<'a>
+    where
+        X: for<'a> elliptic_curve::hash2curve::ExpandMsg<'a>,
     {
         use elliptic_curve::hash2curve::Expander;
         let dst = [dst];

--- a/src/fr.rs
+++ b/src/fr.rs
@@ -713,8 +713,14 @@ impl Field for Fr {
 impl PrimeField for Fr {
     type Repr = [u8; 32];
 
-    fn from_repr(r: Self::Repr) -> CtOption<Self> {
-        Self::from_bytes(&r)
+    fn from_repr(mut r: Self::Repr) -> CtOption<Self> {
+        Self::from_bytes(&r).or_else(|| {
+            r.reverse();
+            let mut bytes = [0u8; 64];
+            bytes[..32].copy_from_slice(&r);
+            let s = Self::from_bytes_wide(&bytes);
+            CtOption::new(s, !s.is_zero())
+        })
     }
 
     fn to_repr(&self) -> Self::Repr {

--- a/src/fr.rs
+++ b/src/fr.rs
@@ -663,6 +663,19 @@ impl Fr {
 
         Fr([d0 & mask, d1 & mask, d2 & mask, d3 & mask])
     }
+
+    /// Hash data to a scalar
+    pub fn hash<X>(msg: &[u8], dst: &[u8]) -> Self
+        where X: for<'a> elliptic_curve::hash2curve::ExpandMsg<'a>
+    {
+        use elliptic_curve::hash2curve::Expander;
+        let dst = [dst];
+        let msg = [msg];
+        let mut expander = X::expand_message(&msg, &dst, 64).expect("hash_to_scalar failed");
+        let mut buf = [0u8; 64];
+        expander.fill_bytes(&mut buf);
+        Fr::from_bytes_wide(&buf)
+    }
 }
 
 impl From<Fr> for [u8; 32] {

--- a/src/fr.rs
+++ b/src/fr.rs
@@ -804,6 +804,8 @@ impl PrimeFieldBits for Fr {
     }
 }
 
+impl_serde!(Fr);
+
 #[test]
 fn test_constants() {
     assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,10 @@ mod fr;
 pub use bls12_381_plus::Scalar as Fq;
 pub use fr::Fr;
 
+pub use group;
+pub use ff;
+pub use bls12_381_plus;
+
 /// Represents an element of the base field $\mathbb{F}_q$ of the Jubjub elliptic curve
 /// construction.
 pub type Base = Fq;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1160,9 +1160,6 @@ impl SubgroupPoint {
 
     /// The identity of the prime-order subgroup.
     pub const IDENTITY: Self = SubgroupPoint(ExtendedPoint::IDENTITY);
-
-    /// The generator of the prime-order subgroup
-    pub const GENERATOR: Self = SubgroupPoint(ExtendedPoint::GENERATOR);
 }
 
 impl<T> Sum<T> for SubgroupPoint

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ use group::{
 };
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use serde::{Deserialize, Serialize};
+
+
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -141,7 +144,7 @@ impl ConditionallySelectable for AffinePoint {
 /// * Add it to an `ExtendedPoint`, `AffineNielsPoint` or `ExtendedNielsPoint`.
 /// * Double it using `double()`.
 /// * Compare it with another extended point using `PartialEq` or `ct_eq()`.
-#[derive(Clone, Copy, Debug, Eq)]
+#[derive(Clone, Copy, Debug, Eq, Serialize, Deserialize)]
 pub struct ExtendedPoint {
     u: Fq,
     v: Fq,

--- a/tests/fq_blackbox.rs
+++ b/tests/fq_blackbox.rs
@@ -8,7 +8,7 @@ fn test_to_and_from_bytes() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
-        assert_eq!(a, Fq::from_bytes(&Fq::to_bytes(&a)).unwrap());
+        assert_eq!(a, Fq::from_le_bytes(&Fq::to_le_bytes(&a)).unwrap());
     }
 }
 
@@ -28,8 +28,8 @@ fn test_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
-        assert_eq!(a, a + Fq::zero());
-        assert_eq!(a, Fq::zero() + a);
+        assert_eq!(a, a + Fq::ZERO);
+        assert_eq!(a, Fq::ZERO + a);
     }
 }
 
@@ -38,8 +38,8 @@ fn test_subtract_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
-        assert_eq!(a, a - Fq::zero());
-        assert_eq!(a, Fq::zero() - -&a);
+        assert_eq!(a, a - Fq::ZERO);
+        assert_eq!(a, Fq::ZERO - -&a);
     }
 }
 
@@ -49,8 +49,8 @@ fn test_additive_inverse() {
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
         let a_neg = -&a;
-        assert_eq!(Fq::zero(), a + a_neg);
-        assert_eq!(Fq::zero(), a_neg + a);
+        assert_eq!(Fq::ZERO, a + a_neg);
+        assert_eq!(Fq::ZERO, a_neg + a);
     }
 }
 
@@ -81,8 +81,8 @@ fn test_multiplicative_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
-        assert_eq!(a, a * Fq::one());
-        assert_eq!(a, Fq::one() * a);
+        assert_eq!(a, a * Fq::ONE);
+        assert_eq!(a, Fq::ONE * a);
     }
 }
 
@@ -91,12 +91,12 @@ fn test_multiplicative_inverse() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
-        if a == Fq::zero() {
+        if a == Fq::ZERO {
             continue;
         }
         let a_inv = a.invert().unwrap();
-        assert_eq!(Fq::one(), a * a_inv);
-        assert_eq!(Fq::one(), a_inv * a);
+        assert_eq!(Fq::ONE, a * a_inv);
+        assert_eq!(Fq::ONE, a_inv * a);
     }
 }
 
@@ -115,7 +115,7 @@ fn test_multiply_additive_identity() {
     let mut rng = new_rng();
     for _ in 0..NUM_BLACK_BOX_CHECKS {
         let a = Fq::new_random(&mut rng);
-        assert_eq!(Fq::zero(), Fq::zero() * a);
-        assert_eq!(Fq::zero(), a * Fq::zero());
+        assert_eq!(Fq::ZERO, Fq::ZERO * a);
+        assert_eq!(Fq::ZERO, a * Fq::ZERO);
     }
 }

--- a/tests/shamir.rs
+++ b/tests/shamir.rs
@@ -1,0 +1,47 @@
+use ff::Field;
+use rand_core::{CryptoRng, RngCore, SeedableRng};
+use vsss_rs::FeldmanVerifierSet;
+
+struct TestingRng(rand_xorshift::XorShiftRng);
+
+impl SeedableRng for TestingRng {
+    type Seed = <rand_xorshift::XorShiftRng as SeedableRng>::Seed;
+
+    fn from_seed(seed: Self::Seed) -> Self {
+        TestingRng(rand_xorshift::XorShiftRng::from_seed(seed))
+    }
+}
+
+impl RngCore for TestingRng {
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+impl CryptoRng for TestingRng {}
+
+#[test]
+fn test_feldman() {
+    let mut rng = TestingRng::from_seed([3u8; 16]);
+    let secret_key = jubjub::Scalar::random(&mut rng);
+    let (shares, verifiers) = vsss_rs::feldman::split_secret::<jubjub::SubgroupPoint, u8, Vec<u8>>(
+        3, 4, secret_key, None, rng,
+    )
+    .unwrap();
+    for share in &shares {
+        println!("Share: {:?}", share);
+        assert!(verifiers.verify_share(share).is_ok());
+    }
+}


### PR DESCRIPTION
Fixing a compile issue when using the latest `bls12_381_plus@v0.8.14` version.
Tested only at https://github.com/LIT-Protocol/js-sdk/pull/341/commits/cf8e897b7557ec33368654956f960cebbbaab86f.
Please make sure this change does not break other build configurations before merging.